### PR TITLE
Fixing HostName to Hostname as that seems to have changed

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -158,7 +158,7 @@ func CreateDevice(projectID, hostname, plan, facility, operatingSystem, billingC
 	}
 
 	req := packngo.DeviceCreateRequest{
-		HostName:     hostname,
+		Hostname:     hostname,
 		Plan:         plan,
 		Facility:     facility,
 		OS:           operatingSystem,
@@ -185,7 +185,7 @@ func CreateDeviceVerbose(projectID, hostname, plan, facility, operatingSystem, b
 	}
 
 	req := packngo.DeviceCreateRequest{
-		HostName:     hostname,
+		Hostname:     hostname,
 		Plan:         plan,
 		Facility:     facility,
 		OS:           operatingSystem,


### PR DESCRIPTION
Looks like the cleaned up some vars on HostName=>Hostname in the github.com/packethost/packngo lib. Thanks!