### PR TITLE
Fix PaymentMethodID

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -105,7 +105,7 @@ func UpdateProject(id, name, paymentID string) error {
 	req := packngo.ProjectUpdateRequest{
 		ID:            id,
 		Name:          name,
-		PaymentMethod: paymentID,
+		PaymentMethodID: paymentID,
 	}
 
 	p, _, err := client.Projects.Update(&req)


### PR DESCRIPTION
Thanks for the packet cli.
I installed it today again, but got an error

```
# github.com/ebsarr/packet/cmd
/go/src/github.com/ebsarr/packet/cmd/api.go:108:16: unknown field 'PaymentMethod' in struct literal of type packngo.ProjectUpdateRequest
Exited with code 2
```

I think this should be fixed with PaymentMethodID